### PR TITLE
Update class-haet-mail.php

### DIFF
--- a/includes/class-haet-mail.php
+++ b/includes/class-haet-mail.php
@@ -719,14 +719,15 @@ final class Haet_Mail {
 		$template_path        = locate_template( 'wp-html-mail/template.html' );
 		$upload_dir           = wp_upload_dir();
 		$custom_template_path = trailingslashit( $upload_dir['basedir'] ) . 'wp-html-mail/template.html';
-		$haet_path            = HAET_MAIL_PATH . 'views/template/template.html';
-
+		
 		if ( ! file_exists( $template_path ) ) {
 			$template_path = $custom_template_path;
 			if ( ! file_exists( $custom_template_path ) ) {
 				$template_path = HAET_MAIL_PATH . 'views/template/template.html';
 			}
 		}
+		
+		$template_path = apply_filters( 'haet_mail_template_path', $template_path );
 
 		if ( is_file( $template_path ) ) {
 			ob_start();
@@ -737,7 +738,6 @@ final class Haet_Mail {
 		}
 		return $template_content;
 	}
-
 
 
 	private function get_header( $options ) {


### PR DESCRIPTION
Updated load_template_file function.  Removed unused $haet_path variable, added 'haet_mail_template_path filter' to allow custom email template to be loaded from other locations like a custom theme directory and not just theme directory or wp upload directory.